### PR TITLE
add a no documentation recovery card

### DIFF
--- a/cards.tex
+++ b/cards.tex
@@ -33,7 +33,7 @@
 \Delivery{A}{Silent pipeline changes}{We won't notice when someone alters the deploy pipeline.}
 %
 % Recovery
-\Recovery{2}{-}{-}
+\Recovery{2}{No documentation}{We do not have (printed) documentation how to restore from backups.}
 \Recovery{3}{No restore}{We have backups but do not check regularly whether we can restore them or not.}
 \Recovery{4}{No infrastructure backups}{We have no backups for our infrastructure (IaC and its state).}
 \Recovery{5}{No backups of data}{We have no backups of our application data.}


### PR DESCRIPTION
The 'no documentation' card indicates that the steps on how to recover are not (physically) available. Recovery can be a stressful time, in particular if business data is involved or availability targets may be missed. An understandable and tested playbook for recovery is a great tool for injecting calm into this situation. For larger setups, it may even be vital in case the engineer on call - at 3am on a Sunday, naturally - needs to recover a system that they do not develop themselves. Printed documentation is relevant in particular if your system that contains the documentation on how to recover from backup itself needs to be recovered.